### PR TITLE
Email setup

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -2,3 +2,7 @@ SECRET_KEY="8ub$w5qhvy#s^vd1+t#)*)wpmue@s6h)+d1%ycsk1&o+2fa&-p"
 DEBUG=1
 DJANGO_ALLOWED_HOSTS="localhost 127.0.0.1 [::1]"
 COMPOSE_PROJECT_NAME=market_dev
+EMAIL_HOST=
+EMAIL_HOST_USER=
+EMAIL_HOST_PASS=
+EMAIL_PORT=

--- a/config/settings.py
+++ b/config/settings.py
@@ -141,5 +141,15 @@ LOGIN_REDIRECT_URL = 'market:home'
 # After logout, redirect to home
 LOGOUT_REDIRECT_URL = 'market:home'
 
-# Email backend - corrently mails are being send to console (need to be changed in production)
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+# Email settings
+# In development, send emails to console. In production use settings specified in .env
+smtp_host = os.environ.get("EMAIL_HOST")
+if smtp_host is None or smtp_host == "":
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+else:
+    EMAIL_HOST = smtp_host
+    EMAIL_PORT = os.environ.get("EMAIL_PORT")
+    EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
+    EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
+    EMAIL_USE_TLS = True
+    EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'

--- a/config/settings.py
+++ b/config/settings.py
@@ -142,7 +142,7 @@ LOGIN_REDIRECT_URL = 'market:home'
 LOGOUT_REDIRECT_URL = 'market:home'
 
 # Email settings
-DEFAULT_FROM_EMAIL = 'markedsspillet@dataekspeditioner.dk'
+DEFAULT_FROM_EMAIL = 'Markedsspillet <markedsspillet@dataekspeditioner.dk>'
 
 # In development, send emails to console. In production use settings specified in .env
 smtp_host = os.environ.get("EMAIL_HOST")

--- a/config/settings.py
+++ b/config/settings.py
@@ -142,6 +142,8 @@ LOGIN_REDIRECT_URL = 'market:home'
 LOGOUT_REDIRECT_URL = 'market:home'
 
 # Email settings
+DEFAULT_FROM_EMAIL = 'markedsspillet@dataekspeditioner.dk'
+
 # In development, send emails to console. In production use settings specified in .env
 smtp_host = os.environ.get("EMAIL_HOST")
 if smtp_host is None or smtp_host == "":


### PR DESCRIPTION
Requires the following lines to be set in .env file used in production:

```
EMAIL_HOST=smtp.eu.mailgun.org
EMAIL_HOST_USER=username@mg.domain.dk
EMAIL_HOST_PASSWORD=secret-password-here
EMAIL_PORT=587
```

If they are not set, it will fallback to the console email backend, which is what we do in our development setup.