### PR TITLE
better handling of invalid trade forms

### DIFF
--- a/market/models.py
+++ b/market/models.py
@@ -137,12 +137,13 @@ class Trade(models.Model):
     # unit price can be null because 'forced trades' have no unit_price
     unit_price = models.DecimalField(
         null=True,
+        blank=False,
         max_digits=12,
         decimal_places=2,
     )
     # unit_amount is the number of products produced
     # unit_amount can be null, because 'forced trades' have no unit_amount
-    unit_amount = models.IntegerField(null=True)
+    unit_amount = models.IntegerField(null=True, blank=False)
 
     round = models.IntegerField()  # not always equal to trader.market.round
     # a trade 'was forced' if the trader did not make a trade decision in the given round.

--- a/market/templates/market/play.html
+++ b/market/templates/market/play.html
@@ -203,7 +203,7 @@ function responsive_title(){
 }
 function responsive_padding(){
     // No top and bottom padding on smalls screens
-    // Padding will take up the space needed for the graps
+    // Padding will take up the space needed for the graphs
 
     if (window.innerWidth < 600) {
         return {'top':0, 'bottom':0}

--- a/market/tests/test_forms.py
+++ b/market/tests/test_forms.py
@@ -420,3 +420,15 @@ class TradeFormTest(TestCase):
         new_trade.round = trader.market.round
         new_trade.save()
         self.assertEqual(Trade.objects.all().count(), 1)
+
+    def test_no_input_is_not_valid(self):
+        """ Blank fields invalides form """
+        trader = TraderFactory(prod_cost=0, balance=201)
+        data = {
+            'unit_price': '',
+            'unit_amount': ''
+        }
+        form = TradeForm(trader, data=data)
+        self.assertFalse(form.is_valid())
+        self.assertTrue('unit_price' in form.errors)
+        self.assertTrue('unit_amount' in form.errors)

--- a/market/views.py
+++ b/market/views.py
@@ -325,18 +325,16 @@ def play(request):
 
         if request.method == 'POST':
             form = TradeForm(data=request.POST)
-            assert(form.is_valid), 'TradeForm invalid - This should not be possible'
             if form.is_valid():
                 new_trade = form.save(commit=False)
                 new_trade.trader = trader
                 new_trade.round = market.round
                 new_trade.balance_before = trader.balance
                 new_trade.save()
-            return redirect(reverse('market:play'))
+                return redirect(reverse('market:play'))
+        else:
+            form = TradeForm(trader)
 
-        # Get requests only :
-
-        form = TradeForm(trader)
         round_stats = RoundStat.objects.filter(market=market)
         trades = Trade.objects.filter(trader=trader)
 


### PR DESCRIPTION
Jeg har stadig ikke kunnet reproducere fejlen nævnt i issue 118, hverken i Chrome eller Firefox. Men fejlen burde i det mindste blive håndteret bedre efter disse ændringer. 