### PR TITLE
attempt at fixing issue 118

### DIFF
--- a/market/forms.py
+++ b/market/forms.py
@@ -72,7 +72,6 @@ class MarketUpdateForm(MarketForm):
             'max_cost': forms.NumberInput(attrs={'readonly': True}),
         }
 
-
     def clean(self):
         """ 
         Max numner of rounds can't be smaller than current round + 1 (when endless = False) 
@@ -162,9 +161,15 @@ class TradeForm(forms.ModelForm):
                 max_unit_amount = floor((trader.balance/trader.prod_cost))
             else:  # if prod_cost is 0 (this is currently not allowed to happen)
                 max_unit_amount = 10000  # this number is arbitrary
-
             self.fields['unit_amount'].widget.attrs['max'] = max_unit_amount
+
             self.fields['unit_price'].help_text = (_("Set a price for one {0} (your cost pr. {0} is <b>{1}</b> kr.)")).format(
                 trader.market.product_name_singular, trader.prod_cost)
             self.fields['unit_amount'].help_text = (
                 _("How many {0} do you want to produce?")).format(trader.market.product_name_plural)
+
+            # Set default value of price slider equal to the trader's prod cost
+            self.fields['unit_price'].widget.attrs['value'] = trader.prod_cost
+
+            # Set default value of amount slider equal to zero
+            self.fields['unit_amount'].widget.attrs['value'] = 0

--- a/market/templates/market/play.html
+++ b/market/templates/market/play.html
@@ -373,10 +373,6 @@ function responsive_padding(){
     
     var amount_slider = document.getElementById("id_unit_amount");
     var price_slider = document.getElementById("id_unit_price");
-    {% if not wait %}
-        amount_slider.value = "{{ trades.last.unit_amount }}"
-        price_slider.value = "{{ trades.last.unit_price }}"
-    {% endif %}
     var balance = parseFloat("{{ trader.balance }}".replace(',', '.'))
     var unit_prod_cost = parseFloat("{{ trader.prod_cost }}".replace(',', '.'))
     var total_cost = document.getElementById('total_cost');


### PR DESCRIPTION
Kunne ikke lige lade være med at give det et skud. Jeg har på fornemmelsen, at problemet skyldes denne passage i play.html:

{% if not wait %}
     (...)
      {% if not wait %} <<--- giver ingen mening her. Der stod en anden betingelse tidligere. 
              amount_slider.value = "{{ trades.last.unit_amount }}"
              price_slider.value = "{{ trades.last.unit_price }}"
      {% endif %}
     (...)
{% if not wait %}

Min pointe var oprindeligt, at jeg ville indstille slideren til som default at vise spillerens valg fra runden før.  Jeg har nu slettet denne kodeblok. I stedet har jeg i forms.py gjort valgt følgende: 

- pris-slideren indstilles nu som udgangspunkt til at være lig med spillerens produktionsomkostning (dette hjælper til at tydeliggøre produktionsomkostningen, som det jo ikke lykkedes os at få vist med en pil under slideren)
- amount-slideren indstilles til som udgangspunkt at være lig 0 (dette sikres, at næsten alle tallene i beregningerne nedenfor formen går i 0 som udgangspunkt.

Hvad siger du til dette? Og afhjælper det dit problem?


