### PR TITLE
Løsning på issue 108 & generelle forbedringer relateret til grafer

### DIFF
--- a/market/templates/market/monitor.html
+++ b/market/templates/market/monitor.html
@@ -140,11 +140,7 @@
         <div id="collapse_balance" class="collapse" aria-labelledby="heading_balance" data-parent="#accordion">
             <div class="card-body">  
                 <div class="mb-5">
-                    {% if traders %}
-                        <canvas id="balanceCanvas"></canvas>
-                    {% else %}
-                        <div class="text-muted">No data to show yet.</div>
-                    {% endif %}
+                    <canvas id="balanceCanvas"></canvas>
                 </div>
             </div>
         </div>
@@ -160,11 +156,7 @@
         <div id="collapse_price" class="collapse" aria-labelledby="heading_price" data-parent="#accordion">
             <div class="card-body">
                 <div class="mb-5">
-                    {% if traders %}
                     <canvas id="priceCanvas"></canvas>
-                    {% else %}
-                        <div class="text-muted">No data to show yet.</div>
-                    {% endif %}
                 </div>
             </div>
         </div>
@@ -180,18 +172,13 @@
         <div id="collapse_amount" class="collapse" aria-labelledby="heading_amount" data-parent="#accordion">
             <div class="card-body">
                 <div class="mb-5">
-                    {% if traders %}
                     <canvas id="amountCanvas"></canvas>
-                    {% else %}
-                        <div class="text-muted">No data to show yet.</div>
-                    {% endif %}
                 </div>
             </div>
         </div>
     </div>
 </div>
 <br><br>
-
 
 <h4>Tabular Data</h4>
 <div id="accordion">
@@ -252,8 +239,7 @@
         </div>
     </div>
     {% endfor %}
-</div>
-
+</div> 
 <br><br>
 
 {% comment %} <div class="d-flex justify-content-center">
@@ -278,110 +264,127 @@
 
 <!-- import Chart.js library-->
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+<!-- Settings for the three charts -->
 <script>
-    {% if traders %}
-
-    const balanceData = {
-        labels: JSON.parse("{{ round_labels_json }}"), // labels on x-axis
-        datasets: {{ balanceDataSet|safe }}
-    }; 
-    balanceData.labels.push("Final")
-
-    const priceData = {
-        labels: JSON.parse("{{ round_labels_json }}"), // labels on x-axis
-        datasets: {{ priceDataSet|safe }}
-    };
+ 
+    // Global settings for charts on this page
+    Chart.defaults.plugins.title.display = true;
+    Chart.defaults.plugins.title.padding = {top:5, bottom:10};
+    Chart.defaults.scales.linear.beginAtZero = true; // y axes is forced to include 0    
   
-    const amountData = {
-        labels: JSON.parse("{{ round_labels_json }}"), // labels on x-axis
-        datasets: {{ amountDataSet|safe }}
-    };
-    const configBalance = {
+    
+    function format_amount_labels(value, index, values){
+        // Default format of 5000 on axis is 5,000. 
+        // Here we change this to 5000.00
+        return value.toFixed(2) 
+    }
+
+    // Balance chart 
+    balance_labels = JSON.parse("{{ round_labels_json }}"), // labels on x-axis
+    balance_labels.push("Final")
+    var balanceChart = new Chart(document.getElementById('balanceCanvas'), {
         type: 'line',
-        data: balanceData,
+        data: {
+            labels : balance_labels,
+            datasets: {{ balanceDataSet|safe }}
+        },
         options: {
             scales: {
                 y: {
-                    beginAtZero: true
-                }        
+                    title:{ 
+                        text: 'Balance (kr.)',
+                        display: 'true'
+                    },
+                    ticks: {
+                        callback: format_amount_labels
+                    },
+                    suggestedMax: parseInt("{{ market.initial_balance }}"),
+                },
+                x: {
+                    title:{ 
+                        text: 'Round',
+                        display: 'true'
+                    }
+                },            
             },  
             plugins: {
                 title: {
-                    display: true,
-                    text: "{% translate 'Balance each round' %}",
-                    padding: {
-                        top: 5,
-                        bottom: 10
-                    }
+                    text: "{% translate 'Balance' %}",
                 }
             }
         }     
-    }
-    const configPrice = {
+    });
+
+    // Price chart
+    var priceChart = new Chart(document.getElementById('priceCanvas'),{
         type: 'line',
-        data: priceData,
+        data: {
+            labels: JSON.parse("{{ round_labels_json }}"), // labels on x-axis
+            datasets: {{ priceDataSet|safe }}
+        },
         options: {
             scales: {
                 y: {
-                    beginAtZero: true
-                }         
+                    title:{ 
+                        text: 'Unit price (kr.)',
+                        display: 'true'
+                    },
+                    ticks: {
+                        callback: format_amount_labels
+                    },
+                    suggestedMax: 2*parseInt("{{ market.max_cost }}"),
+
+                },
+                x: {
+                    title:{
+                        text: 'Round',
+                        display: 'true'
+                    }
+                },         
             },  
             plugins: {
                 title: {
-                    display: true,
-                    text: "{% translate 'Unit price in each round' %}",
-                    padding: {
-                        top: 5,
-                        bottom: 10
-                    }
+                    text: "{% translate 'Unit price' %}",
                 }
             }
         }     
-    }
+    });
 
-    const configAmount = {
+
+    // Amount Chart
+    var amountChart = new Chart(document.getElementById('amountCanvas'), {
         type: 'line',
-        data: amountData,
-        options: {
+        data: {
+            labels: JSON.parse("{{ round_labels_json }}"), // labels on x-axis
+            datasets: {{ amountDataSet|safe }}
+        },
+        options:{
             scales: {
                 y: {
-                    beginAtZero: true
-                }         
+                    title:{ 
+                        text: 'Units produced',
+                        display: 'true'
+                    },
+                    suggestedMax: 100,
+
+                },
+                x: {
+                    title:{ 
+                        text: 'Round',
+                        display: 'true'
+                    }
+                },         
             },  
             plugins: {
                 title: {
-                    display: true,
-                    text: "{% translate 'Units produced in each round' %}",
-                    padding: {
-                        top: 5,
-                        bottom: 10
-                    }
+                    text: "{% translate 'Units produced' %}",
                 }
             }
-        }     
-    }
-    balanceCanvas = document.getElementById('balanceCanvas')
-    priceCanvas = document.getElementById('priceCanvas')
-    amountCanvas = document.getElementById('amountCanvas')
-
-    var myChart = new Chart(
-        balanceCanvas,
-        configBalance
-    );
-
-    var myChart = new Chart(
-        priceCanvas,
-        configPrice
-    );
-
-    var myChart = new Chart(
-        amountCanvas,
-        configAmount
-    );
-
+        }
+    });
+    
 
 </script>
-
-{% endif %}
 
 {% endblock %}

--- a/market/templates/market/monitor.html
+++ b/market/templates/market/monitor.html
@@ -127,6 +127,10 @@
     </div>
 </div>
 
+<div class="d-flex justify-content-center mt-5">
+    <a class="btn btn-secondary" href="{% url 'market:monitor' market.market_id %}">Update graphs</a>
+</div>
+
 <h4>Graphs</h4>
 <div id="accordion">
     <div class="card">
@@ -137,9 +141,9 @@
                 </button>
             </h5>
         </div>
-        <div id="collapse_balance" class="collapse" aria-labelledby="heading_balance" data-parent="#accordion">
+        <div id="collapse_balance" class="collapse show" aria-labelledby="heading_balance">
             <div class="card-body">  
-                <div class="mb-5">
+                <div>
                     <canvas id="balanceCanvas"></canvas>
                 </div>
             </div>
@@ -153,7 +157,7 @@
                 </button>
             </h5>
         </div>
-        <div id="collapse_price" class="collapse" aria-labelledby="heading_price" data-parent="#accordion">
+        <div id="collapse_price" class="collapse show" aria-labelledby="heading_price">
             <div class="card-body">
                 <div class="mb-5">
                     <canvas id="priceCanvas"></canvas>
@@ -169,9 +173,9 @@
                 </button>
             </h5>
         </div>
-        <div id="collapse_amount" class="collapse" aria-labelledby="heading_amount" data-parent="#accordion">
+        <div id="collapse_amount" class="collapse show" aria-labelledby="heading_amount">
             <div class="card-body">
-                <div class="mb-5">
+                <div>
                     <canvas id="amountCanvas"></canvas>
                 </div>
             </div>
@@ -180,6 +184,7 @@
 </div>
 <br><br>
 
+{% comment %} 
 <h4>Tabular Data</h4>
 <div id="accordion">
     {% for field in show_stats_fields %}
@@ -231,19 +236,20 @@
                                 {% endfor %}
                             </tbody>
                         </table>
-                    </div>
-                {% else %}
+                        </div>
+                        {% else %}
                     <p class="text-muted">No data to show yet.</p>
                 {% endif %}
-            </div>
-        </div>
-    </div>
-    {% endfor %}
-</div> 
-<br><br>
+                </div>
+                </div>
+                </div>
+                {% endfor %}
+                </div>
+                <br><br> {% endcomment %}
 
-{% comment %} <div class="d-flex justify-content-center">
-    <button type="button" class="btn btn-primary mb-5" id="next_round_btn" onclick="alert('Feature not implemented yet, sorry')">
+                {% comment %} <div class="d-flex justify-content-center">
+                    <button type="button" class="btn btn-primary mb-5" id="next_round_btn"
+                        onclick="alert('Feature not implemented yet, sorry')">
         Download Data
     </button>
 </div> {% endcomment %}
@@ -251,7 +257,6 @@
 {% endblock %}
 
 {% block javascript %}
-
 <script>
     function copy_join_link() {
         // From w3schools
@@ -265,15 +270,34 @@
 <!-- import Chart.js library-->
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
-<!-- Settings for the three charts -->
+<!-- Chart settings -->
 <script>
  
     // Global settings for charts on this page
     Chart.defaults.plugins.title.display = true;
     Chart.defaults.plugins.title.padding = {top:5, bottom:10};
-    Chart.defaults.scales.linear.beginAtZero = true; // y axes is forced to include 0    
-  
+    Chart.defaults.scales.linear.beginAtZero = true; // y axes is forced to include 0
     
+    function responsive_aspectRatio(){
+        // Set x-axis height relative to y-axis
+        if (window.innerWidth < 600){
+            return 1.3 
+        }
+        else{ 
+            return 2 
+        } 
+    } 
+        
+    function reponsive_display_y_axis_title(){ 
+        // Only show y-axis legend on big enough screens 
+        if (window.innerWidth < 800) { 
+            return false 
+            } 
+            else{
+                 return true
+        }
+    }
+
     function format_amount_labels(value, index, values){
         // Default format of 5000 on axis is 5,000. 
         // Here we change this to 5000.00
@@ -281,8 +305,12 @@
     }
 
     // Balance chart 
-    balance_labels = JSON.parse("{{ round_labels_json }}"), // labels on x-axis
-    balance_labels.push("Final")
+    balance_labels = JSON.parse("{{ round_labels_json }}") // labels on x-axis
+    
+    {% if not market.endless %}
+        balance_labels.push("Final")
+    {% endif %}
+
     var balanceChart = new Chart(document.getElementById('balanceCanvas'), {
         type: 'line',
         data: {
@@ -290,11 +318,12 @@
             datasets: {{ balanceDataSet|safe }}
         },
         options: {
+            aspectRatio: responsive_aspectRatio(),
             scales: {
                 y: {
                     title:{ 
                         text: 'Balance (kr.)',
-                        display: 'true'
+                        display: reponsive_display_y_axis_title()
                     },
                     ticks: {
                         callback: format_amount_labels
@@ -324,17 +353,17 @@
             datasets: {{ priceDataSet|safe }}
         },
         options: {
+            aspectRatio: responsive_aspectRatio(),
             scales: {
                 y: {
                     title:{ 
                         text: 'Unit price (kr.)',
-                        display: 'true'
+                        display: reponsive_display_y_axis_title()
                     },
                     ticks: {
                         callback: format_amount_labels
                     },
                     suggestedMax: 2*parseInt("{{ market.max_cost }}"),
-
                 },
                 x: {
                     title:{
@@ -360,11 +389,12 @@
             datasets: {{ amountDataSet|safe }}
         },
         options:{
+            aspectRatio: responsive_aspectRatio(),
             scales: {
                 y: {
                     title:{ 
-                        text: 'Units produced',
-                        display: 'true'
+                        text: 'Number of units',
+                        display: reponsive_display_y_axis_title()
                     },
                     suggestedMax: 100,
 

--- a/market/templates/market/play.html
+++ b/market/templates/market/play.html
@@ -178,195 +178,6 @@
 
 {% block javascript %}
 
-<!-- Chart.js library -->
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-
-
-<script>
-    // Colors to be used in charts
-    const traderColor = 'rgb(75, 192, 192, 0.6)' 
-    const secondColor = 'rgb(0, 153, 255, 0.6)'
-    const thirdColor = 'rgb(255, 153, 0, 0.6)'
-</script>
-
-
-<script>
-function responsive_title(){
-    // Don't show graph titles on small screens 
-    // Title will take up the space needed for the graphs
-    if (window.innerWidth < 500) {
-        return false
-    }
-    else {
-        return true
-    }
-}
-function responsive_padding(){
-    // No top and bottom padding on smalls screens
-    // Padding will take up the space needed for the graphs
-
-    if (window.innerWidth < 600) {
-        return {'top':0, 'bottom':0}
-    }
-    else{
-        return {'top':5, 'bottom':5}
-    }
-}
-</script>
-
-<script>
-    // Global settings for charts on this page
-    Chart.defaults.plugins.title.display = true;
-    Chart.defaults.plugins.title.padding = {top:5, bottom:10};
-    Chart.defaults.scales.linear.beginAtZero = true; // y axes is forced to include 0    
-
-      
-    function format_amount_labels(value, index, values){
-        // Default format of 5000 on axis is 5,000. 
-        // Here we change this to 5000.00
-        return value.toFixed(2) 
-    }
-
-</script>
-<!-- Balance chart -->
-<script>
-
-    var traderBalanceDataSet = {
-        label: "Your balance",
-        data: JSON.parse("{{ trader_balance_json }}"),
-        lineTension: 0,
-        borderColor: traderColor,
-    };
-
-    var averageBalanceDataSet = {
-        label: "{% translate 'Market average balance' %}",
-        data: JSON.parse("{{ avg_balance_json }}"),
-        lineTension: 0,
-        borderColor: secondColor,
-    };
-    
-    // Balance chart
-    balance_labels = JSON.parse("{{ round_labels_json }}") // labels on x-axis
-    balance_labels.push('Final')
-
-    var lineChart = new Chart(document.getElementById('balanceCanvas'), {
-            type: 'line',
-            data: {
-                labels: balance_labels,
-                datasets: [traderBalanceDataSet, averageBalanceDataSet]
-            },
-            options:{ 
-                plugins: {
-                    title: {
-                        display: responsive_title(),
-                        text: "{% translate 'Balance each round' %}",
-                        padding: responsive_padding()
-                    }
-                }, 
-                 
-            }
-        }
-            
-    );
-    lineChart.height = 500;
-
-</script>
-
-
-<!-- Units chart -->
-<script>
-    unitsCanvas = document.getElementById('unitsCanvas')
-
-    var dataDemand = {
-        label: "{% translate 'Demand' %}",
-        data: JSON.parse("{{ data_demand_json }}"),
-        lineTension: 0,
-        borderColor: traderColor,
-    };
-
-    var dataSold = {
-        label: "{% translate 'Sold' %}",
-        data: JSON.parse("{{ data_sold_json }}"),
-        borderColor: secondColor,
-    };
-
-    var dataProduced = {
-        label: "{% translate 'Produced' %}",
-        data: JSON.parse("{{ data_produced_json }}"),
-        borderColor: thirdColor,
-    };
-
-    var unitsData = {
-        labels: JSON.parse("{{ round_labels_json }}"), // labels on x-axis
-        datasets: [dataDemand,
-				   dataSold,
-				   dataProduced]
-    };
-
-    var lineChart = new Chart(
-        unitsCanvas, {
-            type: 'line',
-            data: unitsData,
-            options: {
-                plugins: {
-                    title: {
-                        display: responsive_title(),
-                        text: "{% translate 'Production history' %}",
-                        padding: responsive_padding()
-                    },
-                },
-            }
-        }
-    );
-</script>
-
-
-
-<!-- Price chart -->
-<script>
-    priceCanvas = document.getElementById('priceCanvas')
-
-    var dataYourPrice = {
-        label: "{% translate 'Your price' %}",
-        data: JSON.parse("{{ data_price_json }}"),
-        lineTension: 0,
-        borderColor: traderColor,
-    };
-
-    var dataMarketAvgPrice = {
-        label: "{% translate 'Market average price' %}",
-        data: JSON.parse("{{ data_market_avg_price_json }}"),
-        borderColor: secondColor,
-    };
-
-    var dataProdCost = {
-        label: "{% translate 'Your unit cost' %}",
-        data: JSON.parse("{{ data_prod_cost_json }}"),
-        borderColor: thirdColor,
-    };
-    var priceData = {
-        labels: JSON.parse("{{ round_labels_json }}"), // labels on x-axis
-        datasets: [dataYourPrice, dataMarketAvgPrice, dataProdCost]
-    };
-
-    var lineChart = new Chart(
-        priceCanvas, {
-            type: 'line',
-            data: priceData,
-            options: {
-                plugins: {
-                    title: {
-                        display: responsive_title(),
-                        text: "{% translate 'Price history' %}",
-                        padding: responsive_padding() 
-                    },
-                }
-            }
-        }
-    );
-</script>
-
-
 {% if not wait %}
 <script>
 
@@ -507,5 +318,210 @@ function responsive_padding(){
     window.setInterval(check_for_next_round, 1000);
 </script>
 {% endif %}
+
+
+<!-- import Chart.js library -->
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+<!-- Chart settings -->
+<script>
+
+    // Global settings for charts on this page
+    Chart.defaults.plugins.title.display = false;
+    Chart.defaults.plugins.title.padding = {top:5, bottom:10};
+    Chart.defaults.scales.linear.beginAtZero = true; // y axes is forced to include 0    
+
+    // Colors to be used in charts
+    const traderColor = 'rgb(75, 192, 192, 0.6)' 
+    const secondColor = 'rgb(0, 153, 255, 0.6)'
+    const thirdColor = 'rgb(255, 153, 0, 0.6)'
+
+    function responsive_aspectRatio(){
+        // Set x-axis height relative to y-axis
+        if (window.innerWidth < 600) {
+            return 1.3
+        }
+        else{
+            return 2
+        }
+    }
+    function reponsive_display_y_axis_title(){
+        // Only show y-axis legend on big enough screens
+        if (window.innerWidth < 1000) {
+            return false
+        }
+        else{
+            return true
+        }
+    }
+
+    function format_amount_labels(value, index, values){
+        // Default format of 5000 on axis is 5,000. 
+        // Here we change this to 5000.00
+        return value.toFixed(2) 
+    }
+
+    // Balance chart 
+    var traderBalanceDataSet = {
+        label: "Your balance",
+        data: JSON.parse("{{ trader_balance_json }}"),
+        lineTension: 0,
+        borderColor: traderColor,
+    };
+
+    var averageBalanceDataSet = {
+        label: "{% translate 'Market average balance' %}",
+        data: JSON.parse("{{ avg_balance_json }}"),
+        lineTension: 0,
+        borderColor: secondColor,
+    };
+    
+    balance_labels = JSON.parse("{{ round_labels_json }}") // labels on x-axis
+    balance_labels.push('Final')
+
+    var lineChart = new Chart(document.getElementById('balanceCanvas'), {
+            type: 'line',
+            data: {
+                labels: balance_labels,
+                datasets: [traderBalanceDataSet, averageBalanceDataSet]
+            },
+            options:{
+                aspectRatio: responsive_aspectRatio(),
+                scales: {
+                    y: {
+                        title:{ 
+                            text: 'Balance (kr.)',
+                            display: reponsive_display_y_axis_title()
+                        },
+                        ticks: {
+                            callback: format_amount_labels
+                        },
+                        suggestedMax: parseInt("{{ market.initial_balance }}"),
+                    },
+                    x: {
+                        title:{ 
+                            text: 'Round',
+                            display: 'true'
+                        }
+                    },            
+                },  
+                plugins: {
+                    title: {
+                        display: true,
+                        text: "{% translate 'Balance' %}",
+                    }
+                }, 
+                 
+            }
+        }     
+    );
+
+    // Price chart
+    var dataYourPrice = {
+        label: "{% translate 'Your price' %}",
+        data: JSON.parse("{{ data_price_json }}"),
+        lineTension: 0,
+        borderColor: traderColor,
+    };
+
+    var dataMarketAvgPrice = {
+        label: "{% translate 'Market average price' %}",
+        data: JSON.parse("{{ data_market_avg_price_json }}"),
+        borderColor: secondColor,
+    };
+
+    var dataProdCost = {
+        label: "{% translate 'Your unit cost' %}",
+        data: JSON.parse("{{ data_prod_cost_json }}"),
+        borderColor: thirdColor,
+    };
+
+    var lineChart = new Chart(priceCanvas = document.getElementById('priceCanvas'),{
+        type: 'line',
+        data: {
+            labels: JSON.parse("{{ round_labels_json }}"), // labels on x-axis
+            datasets: [dataYourPrice, dataMarketAvgPrice, dataProdCost]
+        },
+        options: {
+            aspectRatio: responsive_aspectRatio(),
+            scales: {
+                y: {
+                    title:{ 
+                        text: 'Cost and price (kr.)',
+                        display: reponsive_display_y_axis_title()
+                    },
+                    ticks: {
+                        callback: format_amount_labels
+                    },
+                    suggestedMax: 2*parseInt("{{ market.max_cost }}"),
+                },
+                x: {
+                    title:{ 
+                        text: 'Round',
+                        display: 'true'
+                    }
+                },         
+            },  
+            plugins: {
+                title: {
+                    display: true,
+                    text: "{% translate 'Price history' %}",
+                },
+            }
+        }
+    });
+
+    // Units chart 
+    var dataDemand = {
+        label: "{% translate 'Demand' %}",
+        data: JSON.parse("{{ data_demand_json }}"),
+        lineTension: 0,
+        borderColor: traderColor,
+    };
+
+    var dataSold = {
+        label: "{% translate 'Sold' %}",
+        data: JSON.parse("{{ data_sold_json }}"),
+        borderColor: secondColor,
+    };
+
+    var dataProduced = {
+        label: "{% translate 'Produced' %}",
+        data: JSON.parse("{{ data_produced_json }}"),
+        borderColor: thirdColor,
+    };
+
+    var lineChart = new Chart(document.getElementById('unitsCanvas'), {
+        type: 'line',
+        data: {
+            labels: JSON.parse("{{ round_labels_json }}"), // labels on x-axis
+            datasets: [dataDemand, dataSold, dataProduced] 
+        },
+        options: {
+            aspectRatio: responsive_aspectRatio(),
+            scales: {
+                y: {
+                    title:{ 
+                        text: 'Number of units',
+                        display: reponsive_display_y_axis_title()
+                    },    
+                    suggestedMax: 100,
+                },
+                x: {
+                    title:{
+                        text: 'Round',
+                        display: 'true'
+                    }
+                },         
+            },  
+            plugins: {
+                title: {
+                    display: true,
+                    text: "{% translate 'Production history' %}",
+                },
+            },
+        }
+    });
+</script>
 
 {% endblock javascript%}

--- a/market/templates/market/play.html
+++ b/market/templates/market/play.html
@@ -213,17 +213,23 @@ function responsive_padding(){
     }
 }
 </script>
-<script>
-    const myscales = {
-            y: {
-                    beginAtZero: true
-                }
 
-        }
+<script>
+    // Global settings for charts on this page
+    Chart.defaults.plugins.title.display = true;
+    Chart.defaults.plugins.title.padding = {top:5, bottom:10};
+    Chart.defaults.scales.linear.beginAtZero = true; // y axes is forced to include 0    
+
+      
+    function format_amount_labels(value, index, values){
+        // Default format of 5000 on axis is 5,000. 
+        // Here we change this to 5000.00
+        return value.toFixed(2) 
+    }
+
 </script>
 <!-- Balance chart -->
 <script>
-    balanceCanvas = document.getElementById('balanceCanvas')
 
     var traderBalanceDataSet = {
         label: "Your balance",
@@ -238,19 +244,18 @@ function responsive_padding(){
         lineTension: 0,
         borderColor: secondColor,
     };
-
-    var balanceData = {
-        labels: JSON.parse("{{ round_labels_json }}"), // labels on x-axis
-        datasets: [traderBalanceDataSet, averageBalanceDataSet]
-    };
-
-    balanceData.labels.push('Final')
     
-    var lineChart = new Chart(balanceCanvas, {
+    // Balance chart
+    balance_labels = JSON.parse("{{ round_labels_json }}") // labels on x-axis
+    balance_labels.push('Final')
+
+    var lineChart = new Chart(document.getElementById('balanceCanvas'), {
             type: 'line',
-            data: balanceData,
+            data: {
+                labels: balance_labels,
+                datasets: [traderBalanceDataSet, averageBalanceDataSet]
+            },
             options:{ 
-                scales: myscales,
                 plugins: {
                     title: {
                         display: responsive_title(),
@@ -303,7 +308,6 @@ function responsive_padding(){
             type: 'line',
             data: unitsData,
             options: {
-                scales: myscales, 
                 plugins: {
                     title: {
                         display: responsive_title(),
@@ -350,7 +354,6 @@ function responsive_padding(){
             type: 'line',
             data: priceData,
             options: {
-                scales: myscales, 
                 plugins: {
                     title: {
                         display: responsive_title(),

--- a/market/views.py
+++ b/market/views.py
@@ -7,7 +7,7 @@ from django.views.decorators.http import require_GET, require_POST
 from django.http import HttpResponse
 from .models import Market, Trader, Trade, RoundStat
 from .forms import MarketForm, MarketUpdateForm, TraderForm, TradeForm
-from .helpers import create_forced_trade, filter_trades, process_trade, generate_balance_list, generate_cost_list
+from .helpers import create_forced_trade, filter_trades, process_trade, generate_balance_list, generate_cost_list, add_graph_context_for_monitor_page
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 import json
@@ -177,106 +177,13 @@ def monitor(request, market_id):
                 "The game has ended after {0} rounds!".format(market.round)
             ))
 
-        # Labels for x-axes of graphs
-        if market.endless:
-            round_labels = list(range(1, market.round + 2))
-        else:
-            round_labels = list(range(1, market.max_rounds + 1))
-        context['round_labels_json'] = json.dumps(round_labels)
-
-        # Data for balance and amount graphs
-        # If the app gets slow, we should refactor and optimize
-
-        color_for_averages = 'rgb(173,255,47,0.7)'  # yellow
-
-        def generate_price_list(trader):
-            trades = Trade.objects.filter(trader=trader)
-            return [float(trade.unit_price) if trade.unit_price else None for trade in trades]
-
-        def generate_amount_list(trader):
-            trades = Trade.objects.filter(trader=trader)
-            return [float(trade.unit_amount) if trade.unit_amount else None for trade in trades]
-
-        def trader_color(i):
-            """
-            Pseudo random colors to be used in multi-player plots. 
-            Perhaps we should select the first x colors from a list of colors that look nice together... 
-            """
-            i += 300  # the first few colors look okay with this choice
-            red = (100 + i*100) % 255
-            green = (50 + int((i/3)*100)) % 255
-            blue = (0 + int((i/2)*100)) % 255
-            return f"rgb({red},{green},{blue}, 0.7)"
-
-        balanceDataSet = [{
-            'label': trader.name,
-            'backgroundColor': trader_color(i),
-            'borderColor': trader_color(i),
-            'data': generate_balance_list(trader)
-        }
-            for i, trader in enumerate(traders)
-        ]
-
-        priceDataSet = [{
-            'label': trader.name,
-            'backgroundColor': trader_color(i),
-            'borderColor': trader_color(i),
-            'data': generate_price_list(trader)
-        }
-            for i, trader in enumerate(traders)
-        ]
-
-        amountDataSet = [{
-            'label': trader.name,
-            'backgroundColor': trader_color(i),
-            'borderColor': trader_color(i),
-            'data': generate_amount_list(trader)
-        }
-            for i, trader in enumerate(traders)
-        ]
-
-        rs = RoundStat.objects.filter(market=market).order_by('round')
-        avg_balances = [float(round.avg_balance_after) for round in rs]
-
-        # Adding averages to datasets
-        # We don't want to show an average balance in first round before any traders have joined
-        if market.round > 0 or market.trader_set.count() > 0:
-            avg_balances = [float(market.initial_balance)] + avg_balances
-
-            balanceDataSet.append({
-                'label': 'Average',
-                'backgroundColor': color_for_averages,
-                'borderColor': color_for_averages,
-                'data': avg_balances
-            })
-
-            avg_prices = [float(round.avg_price) for round in rs]
-            priceDataSet.append({
-                'label': 'Average',
-                'backgroundColor': color_for_averages,
-                'borderColor': color_for_averages,
-                'data': avg_prices
-            })
-
-            avg_amounts = [float(round.avg_amount)
-                           if round.avg_amount else None for round in rs]
-
-            amountDataSet.append({
-                'label': 'Avg. amount',
-                'backgroundColor': color_for_averages,
-                'borderColor': color_for_averages,
-                'data': avg_amounts
-            })
-
-        context['balanceDataSet'] = json.dumps(balanceDataSet)
-        context['priceDataSet'] = json.dumps(priceDataSet)
-        context['amountDataSet'] = json.dumps(amountDataSet)
+        # add context for graphs
+        context = add_graph_context_for_monitor_page(context, market, traders)
 
         return render(request, 'market/monitor.html', context)
 
     if request.method == "POST":
         # The host has pressed the 'next round' button
-
         real_trades = filter_trades(market=market, round=market.round)
 
         for trade in real_trades:


### PR DESCRIPTION
- Løser #108 ved hjælp af en custom callback-funktion, der formaterer y-akse-mærkaterne på graferne. 
- Rydder op i graf-definitionerne i javascript i monitor.html og play.html
- Tilføjer titler til x-akserne på alle grafer ("Round"/"Runde").
- Tilføjer titler til y-akserne (f.eks.  "Saldo (kr.)") på skærme, som er store nok. 
- Gør graferne mere synlige på helt små skærme ved at gøre y-aksen højere relativt til x-aksen ("aspectRatio" betyder meget for graferne på små skærme)
- Nu vises graferne på monitor-siden  i runde 0, før der er nogen spillere, der har joinet. Man ser nu tomme grafer i stedet for den kedelige tekst "No data to show yet". For at få dette til at se godt ud, har jeg defineret "suggestedMax"-værdier til y-akserne, så y-akserne viser meningsfulde intervaller, selv når der ingen data er at vise. 
- Der var nogle issues tidligere, hvis værten valgte at reloade monitor-siden midt i en runde. Ny data, gemt i indeværende, uafsluttede runde, ville blive vist på graferne, men ikke altid på en hensigtsmæssig måde. På monitorsiden er der nu en ny knap "Opdatér grafer". Når man trykker på den, reloades siden bare, og man får vist den nyeste data, inklusiv foreløbige gennemsnitsværdier for indeværende runde, på en måde, der forhåbentlig giver mening. 
- Jeg har flyttet produktionen af data til grafer fra monitor-view funktionen i views.py til en hjælpe-funktion i helpers.py. View-funktionen var blevet alt for stor og uoverskuelig + dataen til graferne kan nu bedre testes (hvis vi orker).
- På monitorsiden vises graferne nu udfoldet pr default. Og de kan herefter åbnes og lukkes uafhængigt at hinanden. Det er muligt at vi vælger en helt tredje løsning (f.eks. tabs), men jeg tror, det er bedre nu, end det var før.
- Jeg har kommenteret data-tabellerne ud på monitor-siden, så dataen til tabellerne lige nu hverken genereres eller vises.

Det ene tog det andet, og jeg burde nok have lavet separate pull-requests. Vi kan eventuelt kigge ændringerne igennem sammen, og lige snakke fordele og ulemper, inden der merges. 